### PR TITLE
178MB memory mode for New3DS

### DIFF
--- a/meta/Cthulhu.rsf
+++ b/meta/Cthulhu.rsf
@@ -84,7 +84,7 @@ AccessControlInfo:
   SpecialMemoryArrange          : true
 
   # New3DS Exclusive Process Settings
-  SystemModeExt                 : Legacy # Legacy(Default)/124MB/178MB  Legacy:Use Old3DS SystemMode
+  SystemModeExt                 : 178MB # Legacy(Default)/124MB/178MB  Legacy:Use Old3DS SystemMode
   CpuSpeed                      : 804MHz # 256MHz(Default)/804MHz
   EnableL2Cache                 : true # false(default)/true
   CanAccessCore2                : false 


### PR DESCRIPTION
not actually tested, but this mode has worked on modern cfws today, so it should work the same as Old3DS (home menu not in the background after rebooting).
